### PR TITLE
Fix to problem of drive letter drop on windows implementations.

### DIFF
--- a/setup.lisp
+++ b/setup.lisp
@@ -9,8 +9,24 @@
 (unless *load-truename*
   (error "This file must be LOADed to set up quicklisp."))
 
+(defun has-features (&rest has-features)
+  (every 
+   (lambda (feature)
+     (member feature cl:*features*))
+   has-features))
+
 (defvar *quicklisp-home*
-  (pathname (directory-namestring *load-truename*)))
+  (let ((host (pathname-host *load-truename*))
+	(device (pathname-device *load-truename*))
+	(directory (pathname-directory *load-truename*)))
+  (cond
+    ((or (has-features :windows :ccl)
+	 (has-features :win32 :sbcl)
+	 (has-features :win32 :clisp))
+     (make-pathname :device device :directory directory))
+    ((has-features :lispworks :win32) 
+     (make-pathname :host host :directory directory))
+    (t (pathname (directory-namestring *load-truename*))))))
 
 (defun qmerge (pathname)
   (merge-pathnames pathname *quicklisp-home*))


### PR DESCRIPTION
Fix to problem of drive letter drop ql:_quicklisp-home_.

Lisp implementation on windows that has drive letter on pathname-device or pathname-host. But ql:_quicklisp-home_'s initialize code is build on only directory-namestirng.

I confirmed to SBCL, CLISP, ClozureCL and Lispworks personal(for WINDOWS).
I'm not confirmed to AllegroCL, ECL, ABCL. Please add code these implementation support.

I'm sorry in strange english.

Thunk you.
