### PR TITLE
Work-around for ECL bug #3161786

### DIFF
--- a/quicklisp.lisp
+++ b/quicklisp.lisp
@@ -388,6 +388,7 @@
 
 (definterface read-octets (buffer connection)
   (:implementation t
+    ;; ECL bug #3161786.
     (if (equal (stream-element-type connection)
                '(unsigned-byte 8))
       (read-sequence buffer connection)


### PR DESCRIPTION
Hi,

I went on to install Quicklisp using ECL 11.1.1 in Windows 7 64-bit and I ran into an issue. Specifically, bug number 3161786 http://sourceforge.net/tracker/index.php?func=detail&aid=3161786&group_id=30035&atid=398053.

I've tried to fix it, and seems to work fine so far. However, I had to install Quicklisp inside the Visual Studio command prompt so that "sys/types.h" could be found by ECL when executing the CL compiler. Maybe a warning could be added if the compilation fails on Windows so that the user can double check his environment?
