### PR TITLE
Fix distinfo URL from version

### DIFF
--- a/quicklisp.lisp
+++ b/quicklisp.lisp
@@ -1731,7 +1731,7 @@ the indexes in the header accordingly."
           version))
 
 (defun distinfo-url-from-version (version)
-  (format nil "http://~A/dist/~A/distinfo.txt"
+  (format nil "http://~A/dist/quicklisp/~A/distinfo.txt"
           *quicklisp-hostname*
           version))
 


### PR DESCRIPTION
The working URL [in this post](http://blog.quicklisp.org/2011/08/going-back-in-dist-time.html) is `/dist/quicklisp/` instead of just `/dist/`

This should fix `(quicklisp-quickstart:install :dist-version "2016-02-08")` which currently throws:

```
Unexpected HTTP status for #<URL
                               "http://beta.quicklisp.org/dist/2016-02-08/distinfo.txt">: 403
```