### PR TITLE
more compact file, and slightly faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
 
 tag:
-	test -z "`git status -s quicklisp.lisp`"
-	git tag version-`grep 'defvar qlqs-info:.version.' quicklisp.lisp | cut -d\" -f 2`
+	test -z "$(git status -s quicklisp.lisp)"
+	git tag version-$(grep 'defvar qlqs-info:.version.' quicklisp.lisp | cut -d\" -f 2)

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ all:
 
 tag:
 	test -z "$(git status -s quicklisp.lisp)"
-	git tag version-$(grep 'defvar qlqs-info:.version.' quicklisp.lisp | cut -d\" -f 2)
+	git tag version-$(grep -Eohm1 2[0-9-]{9} quicklisp.lisp)


### PR DESCRIPTION
time echo version-$(grep -Eohm1 2[0-9-]{9} quicklisp.lisp) 
-> version-2015-01-28

real	0m0,005s 
user	0m0,000s
sys	0m0,000s

time echo version-`grep 'defvar qlqs-info:.version.' quicklisp.lisp | cut -d\" -f 2` 
-> version-2015-01-28

real	0m0,010s

time echo version-$(grep 'defvar qlqs-info:.version.' quicklisp.lisp | cut -d\" -f 2)
version-2015-01-28

real	0m0,066s

time echo version-`grep -Eohm1 2[0-9-]{9} quicklisp.lisp`
version-2015-01-28

real	0m0,073s
